### PR TITLE
Documentation: fix process name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 When running the program nothing will show up on your screen, there will also be nothing in your task tray. (this is because I am not smart enough and do not have the time to do this currently).
 
-To turn it off you will have to go into task manager, look for '_StartMenuToPTRun.exe' (which should show close if not at the top), right click it and press end task.
+To turn it off you will have to go into task manager, look for 'CustomTaskbarAndPTRun.exe' (which should show close if not at the top), right click it and press end task.
 
 Feel free to take this code and improve it as you please, I doubt it's that optimised as I spent maybe a few hours on it at best but it uses next to no system resources anyways.
 


### PR DESCRIPTION
The pre-built binary bore an incorrect name (`_StartMenuToPTRun.exe` instead of `CustomTaskbarAndPTRun.exe`).